### PR TITLE
Add support for split in tmux

### DIFF
--- a/scripts/iterm.sh
+++ b/scripts/iterm.sh
@@ -1,14 +1,14 @@
 CMD=""
 WD="$PWD"
-args="$@"
+ARGS="$@"
 
 if [ -d "$1" ]; then
     WD="$1"
-    args="${@:2}"
+    ARGS="${@:2}"
 fi
 
-if [ -n "$args" ]; then
-    CMD="$args"
+if [ -n "$ARGS" ]; then
+    CMD="$ARGS"
 fi
 
     osascript <<EOF

--- a/scripts/tmux.sh
+++ b/scripts/tmux.sh
@@ -1,0 +1,18 @@
+CMD=""
+WD="$PWD"
+ARGS="$@"
+
+if [ -d "$1" ]; then
+    WD="$1"
+    ARGS="${@:2}"
+fi
+
+if [ -n "$ARGS" ]; then
+    CMD="$ARGS"
+fi
+
+currentPane=$(tmux display-message -p '#P')
+newPane=$(($currentPane + 1))
+tmux split-window -$SPLIT_DIRECTION
+tmux select-pane -t "$currentPane"
+tmux send-keys -t "$newPane" C-z "cd $WD;$CMD" Enter

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,21 @@
 import arg from "arg";
 import chalk from "chalk";
 import launchFileInNewTerminal from "./file";
-import command, { Options } from "./command";
+import command from "./command";
+import normalize from "./normalize";
+
+export type InitialOptions = {
+  env?: Record<string, string>;
+  split?: boolean;
+  splitDirection?: string;
+  terminalApp?: string;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require("../package.json");
 
-const error = (message: string): string => chalk`{red ERROR:} ${message}`;
+export const error = (message: string): string =>
+  chalk`{red ERROR:} ${message}`;
 
 const args = arg(
   {
@@ -62,12 +71,14 @@ if ((!files || files?.length === 0) && (!scripts || scripts?.length === 0)) {
   process.exit(1);
 }
 
-const cliOptions: Options = {
+const cliOptions: InitialOptions = {
   env: {},
   split: !!args["--splitDirection"] || args["--split"],
   splitDirection: args["--splitDirection"],
   terminalApp: args["--terminalApp"]
 };
 
-scripts?.forEach(script => command(script, cliOptions));
-files?.forEach(launchFileInNewTerminal);
+const options = normalize(cliOptions);
+
+scripts?.forEach(script => command(script, options));
+files?.forEach(filePath => launchFileInNewTerminal(filePath, options));

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,22 +2,7 @@ import path from "path";
 import tempy from "tempy";
 import fs from "fs";
 import launchTerminal from "./launchTerminal";
-import { detectTerminalApp } from "./utils";
-import merge from "lodash.merge";
-
-export type Options = {
-  env?: Record<string, string>;
-  split?: boolean;
-  splitDirection?: string;
-  terminalApp?: string | undefined;
-};
-
-const defaultOptions: Options = {
-  env: {},
-  split: false,
-  splitDirection: "vertically",
-  terminalApp: detectTerminalApp()
-};
+import { Options } from "./normalize";
 
 function commandWindows(script: string, options: Options): void {
   const launchFilePath = path.join(tempy.directory(), "launchTerminal.bat");
@@ -69,14 +54,12 @@ function commandUnix(script: string, options: Options): void {
   launchTerminal(launchFilePath, options);
 }
 
-export default function command(script: string, options?: Options): void {
-  const optionsWithDefaults = merge(defaultOptions, options);
-
+export default function command(script: string, options: Options): void {
   const isWindows = /^win/.test(process.platform);
 
   if (!isWindows) {
-    commandUnix(script, optionsWithDefaults);
+    commandUnix(script, options);
   } else {
-    commandWindows(script, optionsWithDefaults);
+    commandWindows(script, options);
   }
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,17 +1,18 @@
 import path from "path";
 import command from "./command";
+import { Options } from "./normalize";
 
-export default function file(filePath: string): void {
+export default function file(filePath: string, options: Options): void {
   const absolutePath = path.join(process.cwd(), filePath);
   const extention = path.extname(absolutePath);
 
   switch (extention) {
     case "":
     case ".sh":
-      command(`sh ${absolutePath}`);
+      command(`sh ${absolutePath}`, options);
       break;
     case ".js":
-      command(`node ${absolutePath}`);
+      command(`node ${absolutePath}`, options);
       break;
     default:
       throw new Error(

--- a/src/launchTerminal.ts
+++ b/src/launchTerminal.ts
@@ -1,32 +1,32 @@
-import { linux, mac, windows, iterm } from "./launchers";
-import { Options } from ".//command";
+import { linux, mac, windows, iterm, tmux } from "./launchers";
+import { Options } from "./normalize";
 
 export default function launchTerminal(
   execFilePath: string,
   options: Options
 ): void {
+  const { split, terminalApp } = options;
+
   const platform = process.platform;
   const isWindows = /^win/.test(platform);
   const isMac = /darwin/.test(platform);
   const isLinux = /linux/.test(platform);
-
-  const { split, terminalApp } = options;
+  const isIterm = terminalApp === "iTerm.app";
+  const isTmux = !!process.env.TMUX_PANE;
 
   let launcher;
 
-  if (isMac) {
-    if (split && terminalApp === "iTerm.app") {
+  if (split) {
+    if (isTmux) {
+      launcher = tmux;
+    } else if (isIterm) {
       launcher = iterm;
-    } else {
-      launcher = mac;
     }
-  }
-
-  if (isWindows) {
+  } else if (isMac) {
+    launcher = mac;
+  } else if (isWindows) {
     launcher = windows;
-  }
-
-  if (isLinux) {
+  } else if (isLinux) {
     launcher = linux;
   }
 

--- a/src/launchers.ts
+++ b/src/launchers.ts
@@ -1,6 +1,6 @@
 import execa from "execa";
 import path from "path";
-import { Options } from "./command";
+import { Options } from "./normalize";
 
 export const windows = (execFilePath: string): void => {
   execa.sync("cmd.exe", ["/C", execFilePath], {
@@ -36,5 +36,24 @@ export const iterm = (execFilePath: string, options: Options): void => {
     return;
   } catch (error) {
     mac(execFilePath, options);
+  }
+};
+
+export const tmux = (execFilePath: string, options: Options): void => {
+  try {
+    const tmuxSplitDirection =
+      options.splitDirection === "vertically" ? "h" : "v";
+
+    execa.sync(path.join(__dirname, "../scripts/tmux.sh"), [execFilePath], {
+      ...options.env,
+      env: { SPLIT_DIRECTION: tmuxSplitDirection }
+    });
+    return;
+  } catch (error) {
+    if (options.terminalApp === "iTerm.app") {
+      iterm(execFilePath, options);
+    } else {
+      mac(execFilePath, options);
+    }
   }
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,0 +1,37 @@
+import { InitialOptions, error } from "./cli";
+import merge from "lodash.merge";
+import { detectTerminalApp } from "./utils";
+
+export type Options = {
+  env?: Record<string, string>;
+  split?: boolean;
+  splitDirection: "vertically" | "horizontally" | undefined;
+  terminalApp?: string | undefined;
+};
+
+const defaultOptions: InitialOptions = {
+  env: {},
+  split: false,
+  splitDirection: "vertically",
+  terminalApp: detectTerminalApp()
+};
+
+export default (initialOptions: InitialOptions): Options => {
+  const { splitDirection } = initialOptions;
+
+  if (
+    splitDirection &&
+    splitDirection !== "vertically" &&
+    splitDirection !== "horizontally"
+  ) {
+    throw new Error(
+      error(
+        `splitDirection "${splitDirection}" should be either "vertically" or "horizontally"`
+      )
+    );
+  }
+
+  const optionsWithDefaults = merge(defaultOptions, initialOptions);
+
+  return optionsWithDefaults as Options;
+};

--- a/tmux.sh
+++ b/tmux.sh
@@ -1,5 +1,0 @@
-currentPane=$(tmux display-message -p '#P')
-newPane=$(($currentPane + 1))
-tmux split-window -v
-tmux select-pane -t "$currentPane"
-tmux send-keys -t "$newPane" C-z 'pwd' Enter

--- a/tmux.sh
+++ b/tmux.sh
@@ -1,0 +1,5 @@
+currentPane=$(tmux display-message -p '#P')
+newPane=$(($currentPane + 1))
+tmux split-window -v
+tmux select-pane -t "$currentPane"
+tmux send-keys -t "$newPane" C-z 'pwd' Enter


### PR DESCRIPTION
This PR fixes #3 

![newsh-tmux-split](https://user-images.githubusercontent.com/11733036/74109271-9e340200-4b8a-11ea-8cd9-a372e30a74a4.gif)

I tried to go for the same behavior we have in `iTerm`.
e.g. leave the focus on the original pane. also I needed to switch between the `h` and `v` flags of `tmux` which were the opposite from what you'd expect 😉 

@roymiloh I don't use `tmux` regularly, so if you can review this PR that would be awesome! 