### PR TITLE
Improve tests coverage and infra

### DIFF
--- a/__tests__/command.test.ts
+++ b/__tests__/command.test.ts
@@ -1,16 +1,12 @@
 import * as newsh from "../";
 import tempy from "tempy";
-import path from "path";
-import fs from "fs";
-import waitFor from "p-wait-for";
-import pathExists from "path-exists";
+import { waitForFile, readFile } from "./utils/runNewsh";
 
 const writeFileFuncPath = require.resolve("./utils/writeFile");
 const writeCwdFuncPath = require.resolve("./utils/writeCwd");
 
 test("command is running", async () => {
-  const testDir = tempy.directory();
-  const testFile = path.join(testDir, "test-file");
+  const testFile = tempy.file();
   const testData = "foobar";
 
   newsh.command(`node ${writeFileFuncPath}`, {
@@ -20,24 +16,20 @@ test("command is running", async () => {
     }
   });
 
-  await waitFor(() => pathExists(testFile), { timeout: 4000 });
-
-  const foundTestData = fs.readFileSync(testFile, "utf-8");
-  expect(foundTestData).toBe(testData);
+  await waitForFile(testFile);
+  expect(readFile(testFile)).toBe(testData);
 });
 
 test("command is running in the same cwd", async () => {
-  const testDir = tempy.directory();
-  const testFile = path.join(testDir, "test-file");
+  const testFile = tempy.file();
 
   newsh.command(`node ${writeCwdFuncPath}`, {
     env: {
       __PATH__: testFile
     }
   });
-  await waitFor(() => pathExists(testFile), { timeout: 4000 });
 
-  const foundScriptCwd = fs.readFileSync(testFile, "utf-8");
+  await waitForFile(testFile);
 
-  expect(foundScriptCwd).toBe(process.cwd());
+  expect(readFile(testFile)).toBe(process.cwd());
 });

--- a/__tests__/file.test.ts
+++ b/__tests__/file.test.ts
@@ -4,14 +4,14 @@ import path from "path";
 import fs from "fs";
 import waitFor from "p-wait-for";
 import pathExists from "path-exists";
+import { waitForFile, readFile } from "./utils/runNewsh";
 
 const writeFileFuncPath = require.resolve("./utils/writeFile");
 const writeCwdFuncPath = require.resolve("./utils/writeCwd");
 
 describe("file", () => {
   test("no extension", async () => {
-    const testDir = tempy.directory();
-    const testFile = path.join(testDir, "test-file");
+    const testFile = tempy.file();
     const testData = "foobar";
 
     newsh.file(path.join(__dirname, "./fixtures/writeFile"), {
@@ -22,15 +22,12 @@ describe("file", () => {
       }
     });
 
-    await waitFor(() => pathExists(testFile), { timeout: 4000 });
-
-    const foundTestData = fs.readFileSync(testFile, "utf-8");
-    expect(foundTestData).toBe(testData);
+    await waitForFile(testFile);
+    expect(readFile(testFile)).toBe(testData);
   });
 
   test(".sh", async () => {
-    const testDir = tempy.directory();
-    const testFile = path.join(testDir, "test-file");
+    const testFile = tempy.file();
     const testData = "foobar";
 
     newsh.file(path.join(__dirname, "./fixtures/writeFile.sh"), {
@@ -41,15 +38,12 @@ describe("file", () => {
       }
     });
 
-    await waitFor(() => pathExists(testFile), { timeout: 4000 });
-
-    const foundTestData = fs.readFileSync(testFile, "utf-8");
-    expect(foundTestData).toBe(testData);
+    await waitForFile(testFile);
+    expect(readFile(testFile)).toBe(testData);
   });
 
   test(".js", async () => {
-    const testDir = tempy.directory();
-    const testFile = path.join(testDir, "test-file");
+    const testFile = tempy.file();
     const testData = "foobar";
 
     newsh.file(writeFileFuncPath, {
@@ -59,15 +53,12 @@ describe("file", () => {
       }
     });
 
-    await waitFor(() => pathExists(testFile), { timeout: 4000 });
-
-    const foundTestData = fs.readFileSync(testFile, "utf-8");
-    expect(foundTestData).toBe(testData);
+    await waitForFile(testFile);
+    expect(readFile(testFile)).toBe(testData);
   });
 
   test("running in the same cwd", async () => {
-    const testDir = tempy.directory();
-    const testFile = path.join(testDir, "test-file");
+    const testFile = tempy.file();
 
     newsh.file(writeCwdFuncPath, {
       env: {
@@ -75,10 +66,7 @@ describe("file", () => {
       }
     });
 
-    await waitFor(() => pathExists(testFile), { timeout: 4000 });
-
-    const foundScriptCwd = fs.readFileSync(testFile, "utf-8");
-
-    expect(foundScriptCwd).toBe(process.cwd());
+    await waitForFile(testFile);
+    expect(readFile(testFile)).toBe(process.cwd());
   });
 });

--- a/__tests__/utils/runNewsh.ts
+++ b/__tests__/utils/runNewsh.ts
@@ -1,4 +1,7 @@
 import execa, { CommonOptions } from "execa";
+import fs from "fs";
+import waitFor from "p-wait-for";
+import pathExists from "path-exists";
 
 const newshBin = require.resolve("../../bin/newsh.js");
 
@@ -8,3 +11,28 @@ export default async (
 ): Promise<{ stdout: string; stderr: string }> => {
   return await execa(newshBin, [].concat(args), options);
 };
+
+export async function waitForFile(
+  testFile: string,
+  child?: {
+    stdout: string;
+    stderr: string;
+  }
+): Promise<void> {
+  try {
+    await waitFor(() => pathExists(testFile), { timeout: 4000 });
+  } catch (error) {
+    if (!child) {
+      throw error;
+    }
+
+    throw new Error(`${error.message}
+
+      STDOUT: ${child.stdout}
+      STDERR: ${child.stderr}`);
+  }
+}
+
+export function readFile(file: string): string {
+  return fs.readFileSync(file, "utf-8");
+}


### PR DESCRIPTION
After the [last bug](https://github.com/ranyitz/newsh/commit/b882eee34fdc5df2c1463322e14527f687f6e2ca) it made sense to add some tests to `--split` & `--split-horizontally`, even just to see that the fallback are working.

The infra of the tests was improved as well.