### PR TITLE
Remove merge & fix initial options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   "[typescript]": {
     "editor.formatOnSave": false
   },
+  "typescript.tsdk": "node_modules\\typescript\\lib",
 
 }

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "newsh": "bin/newsh.js"
   },
   "scripts": {
+    "newsh": "node bin/newsh.js",
     "build": "tsc",
-    "watch": "newsh --split 'tsc --watch'",
-    "lint": "eslint '*/**/*.{js,ts}'",
+    "watch": "yarn newsh --split \"tsc --watch\"",
+    "lint": "eslint \"*/**/*.{js,ts}\"",
     "test": "jest",
-    "test:watch": "newsh 'jest --watch'"
+    "test:watch": "yarn newsh \"jest --watch\""
   },
   "husky": {
     "hooks": {
@@ -75,7 +76,6 @@
     "arg": "^4.1.3",
     "chalk": "^3.0.0",
     "execa": "^4.0.0",
-    "lodash.merge": "^4.6.2",
     "tempy": "^0.3.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,14 +10,14 @@ import arg from "arg";
 import chalk from "chalk";
 import launchFileInNewTerminal from "./file";
 import command from "./command";
-import normalize from "./normalize";
 import { ErrorMessage } from "./utils";
 
 export type InitialOptions = {
-  env: NodeJS.ProcessEnv;
-  splitDirection: string | undefined;
-  split: boolean | undefined;
-  terminalApp: string | undefined;
+  env?: NodeJS.ProcessEnv;
+  cwd?: string | undefined;
+  splitDirection?: string | undefined;
+  split?: boolean | undefined;
+  terminalApp?: string | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -85,14 +85,13 @@ const splitDirection = args["--split-vertically"]
   ? "horizontally"
   : undefined;
 
-const cliOptions: InitialOptions = {
+const initialOptions: InitialOptions = {
   env: {},
+  cwd: undefined,
   split: !!splitDirection,
   splitDirection,
   terminalApp: args["--terminalApp"]
 };
 
-const options = normalize(cliOptions);
-
-scripts?.forEach(script => command(script, options));
-files?.forEach(filePath => launchFileInNewTerminal(filePath, options));
+scripts?.forEach(script => command(script, initialOptions));
+files?.forEach(filePath => launchFileInNewTerminal(filePath, initialOptions));

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,7 +2,8 @@ import path from "path";
 import tempy from "tempy";
 import fs from "fs";
 import launchTerminal from "./launchTerminal";
-import { Options } from "./normalize";
+import normalize, { Options } from "./normalize";
+import { InitialOptions } from "./cli";
 
 function commandWindows(script: string, options: Options): void {
   const launchFilePath = path.join(tempy.directory(), "launchTerminal.bat");
@@ -31,9 +32,9 @@ exit`;
 
 function commandUnix(script: string, options: Options): void {
   const launchFilePath = path.join(tempy.directory(), "launchTerminal");
+  const { env } = options;
 
   const environmentParams = [];
-  const { env } = options;
 
   if (env) {
     for (const paramKey in env) {
@@ -56,7 +57,11 @@ function commandUnix(script: string, options: Options): void {
   launchTerminal(launchFilePath, options);
 }
 
-export default function command(script: string, options: Options = {}): void {
+export default function command(
+  script: string,
+  initialOptions: InitialOptions = {}
+): void {
+  const options = normalize(initialOptions);
   const isWindows = /^win/.test(process.platform);
 
   if (!isWindows) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -58,7 +58,7 @@ function commandUnix(script: string, options: Options): void {
   const moveToDirCommand = `cd ${process.cwd()};`;
 
   const scriptWithMovePrefix =
-    moveToDirCommand + "\n" + environmentParams.join("") + "\n" + script;
+    moveToDirCommand + environmentParams.join("") + script;
 
   fs.writeFileSync(launchFilePath, scriptWithMovePrefix);
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -30,6 +30,15 @@ exit`;
   launchTerminal(launchFilePath, options);
 }
 
+// There is a bug when npm create environment params which contains `"`
+// Usually when trying to take npm scripts which contains `\"` in them
+// (e.g. VAR="npm_package_scripts_test_watch="tsc --watch"")
+// They clash with the `"` used for the definition of the variable in bash
+// This is a best effort to assign them by changing them to `'`
+function escapeDoubleQuotes(value: string | undefined): string | undefined {
+  return value?.replace(/"/g, `'`);
+}
+
 function commandUnix(script: string, options: Options): void {
   const launchFilePath = path.join(tempy.directory(), "launchTerminal");
   const { env } = options;
@@ -39,7 +48,9 @@ function commandUnix(script: string, options: Options): void {
   if (env) {
     for (const paramKey in env) {
       if (env[paramKey]) {
-        environmentParams.push(`${paramKey}="${env[paramKey]}" `);
+        environmentParams.push(
+          `${paramKey}="${escapeDoubleQuotes(env[paramKey])}" `
+        );
       }
     }
   }
@@ -47,7 +58,7 @@ function commandUnix(script: string, options: Options): void {
   const moveToDirCommand = `cd ${process.cwd()};`;
 
   const scriptWithMovePrefix =
-    moveToDirCommand + environmentParams.join("") + script;
+    moveToDirCommand + "\n" + environmentParams.join("") + "\n" + script;
 
   fs.writeFileSync(launchFilePath, scriptWithMovePrefix);
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,11 +1,17 @@
 import path from "path";
 import command from "./command";
-import { Options } from "./normalize";
 import { ErrorMessage } from "./utils";
+import { InitialOptions } from "./cli";
+import normalize from "./normalize";
 
-export default function file(filePath: string, options: Options = {}): void {
+export default function file(
+  filePath: string,
+  initialOptions: InitialOptions = {}
+): void {
+  const options = normalize(initialOptions);
+
   if (!path.isAbsolute(filePath)) {
-    filePath = path.join(process.cwd(), filePath);
+    filePath = path.join(options.cwd, filePath);
   }
 
   const extention = path.extname(filePath);

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,23 +1,40 @@
 import { InitialOptions } from "./cli";
-import merge from "lodash.merge";
 import { detectTerminalApp } from "./utils";
 
 export type Options = {
-  env?: NodeJS.ProcessEnv;
-  split?: boolean;
-  splitDirection?: "vertically" | "horizontally";
-  terminalApp?: string;
+  env: NodeJS.ProcessEnv;
+  cwd: string;
+  split: boolean;
+  splitDirection: "vertically" | "horizontally";
+  terminalApp: string | undefined;
 };
 
-const defaultOptions: InitialOptions = {
+const defaultOptions: Options = {
   env: process.env,
+  cwd: process.cwd(),
   split: false,
   splitDirection: "vertically",
   terminalApp: detectTerminalApp()
 };
 
-export default (initialOptions: InitialOptions): Options => {
-  const optionsWithDefaults = merge(defaultOptions, initialOptions);
+function removeUndefinedValues(obj: Record<string, any>) {
+  for (const key in obj) {
+    if (obj[key] === undefined) {
+      delete obj[key];
+    }
+  }
 
-  return optionsWithDefaults as Options;
+  return obj;
+}
+export default (initialOptions: InitialOptions): Options => {
+  const options = {
+    ...defaultOptions,
+    ...removeUndefinedValues(initialOptions),
+    env: {
+      ...defaultOptions.env,
+      ...initialOptions.env
+    }
+  };
+
+  return options as Options;
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -17,6 +17,7 @@ const defaultOptions: Options = {
   terminalApp: detectTerminalApp()
 };
 
+// eslint-disable-next-line
 function removeUndefinedValues(obj: Record<string, any>) {
   for (const key in obj) {
     if (obj[key] === undefined) {
@@ -26,6 +27,7 @@ function removeUndefinedValues(obj: Record<string, any>) {
 
   return obj;
 }
+
 export default (initialOptions: InitialOptions): Options => {
   const options = {
     ...defaultOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,11 +3447,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.merge@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
-  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"


### PR DESCRIPTION
* `lodash.merge` is not needed here, this PR removes it and use a simpler implementation.
* Settle the difference between `InitialOptions` and `Options` - `Options` should be used in the application when we already know the merge between the default options and the possibly undefined `initialOptions` that the user provides.
* Added a mark to the IDE to use the version of typescript provided in the `node_modules`.
* Use `newsh` in local npm scripts and made it work in windows as well.