### PR TITLE
configure retries to kill flakiness in ci

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   testEnvironment: "node",
-  testMatch: ["**/__tests__/**/*.test.[jt]s?(x)"]
+  testMatch: ["**/__tests__/**/*.test.[jt]s?(x)"],
+  testRunner: "jest-circus/runner",
+  setupFilesAfterEnv: ["./jest.setup.js"]
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+if (process.env.CI) {
+  jest.retryTimes(3);
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,3 @@
-if (process.env.CI) {
+if (process.env.GITHUB_ACTIONS) {
   jest.retryTimes(3);
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "husky": "^4.2.1",
     "jest": "^25.1.0",
+    "jest-circus": "^25.1.0",
     "lint-staged": "^10.0.7",
     "p-wait-for": "^3.1.0",
     "path-exists": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,6 +2882,28 @@ jest-changed-files@^25.1.0:
     execa "^3.2.0"
     throat "^5.0.0"
 
+jest-circus@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-25.1.0.tgz#d7c6643ed678975799eafc30653d9867c7fbd326"
+  integrity sha512-Axlcr2YMxVarMW4SiZhCFCjNKhdF4xF9AIdltyutQOKyyDT795Kl/fzI95O0l8idE51Npj2wDj5GhrV7uEoEJA==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^25.1.0"
+    "@jest/test-result" "^25.1.0"
+    "@jest/types" "^25.1.0"
+    chalk "^3.0.0"
+    co "^4.6.0"
+    expect "^25.1.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    jest-message-util "^25.1.0"
+    jest-snapshot "^25.1.0"
+    jest-util "^25.1.0"
+    pretty-format "^25.1.0"
+    stack-utils "^1.0.1"
+    throat "^5.0.0"
+
 jest-cli@^25.1.0:
   version "25.1.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-25.1.0.tgz#75f0b09cf6c4f39360906bf78d580be1048e4372"


### PR DESCRIPTION
The image of windows provided by GitHub actions makes the tests flaky (I only say it because the tests pass locally on my windows machine at home) so I want to try 3 retries for each test to make the tests less flaky.

I can also setup the retries on windows only, but let's start like this.