### PR TITLE
add `${cwd}/node_modules/.bin` to path

### DIFF
--- a/__tests__/command.test.ts
+++ b/__tests__/command.test.ts
@@ -48,7 +48,8 @@ test("command is pushing ${cwd}/node_module/.bin to PATH", async () => {
   await waitForFile(testFile);
 
   const content = readFile(testFile);
-  const firstPATHChunk = content.slice(0, content.indexOf(":"));
+
+  const firstPATHChunk = content.slice(0, content.indexOf(":", 2));
 
   expect(firstPATHChunk).toMatch(`node_modules${path.sep}.bin`);
 });

--- a/__tests__/command.test.ts
+++ b/__tests__/command.test.ts
@@ -1,9 +1,11 @@
 import * as newsh from "../";
+import path from "path";
 import tempy from "tempy";
 import { waitForFile, readFile } from "./utils/runNewsh";
 
 const writeFileFuncPath = require.resolve("./utils/writeFile");
 const writeCwdFuncPath = require.resolve("./utils/writeCwd");
+const writePATHFuncPath = require.resolve("./utils/writePATH");
 
 test("command is running", async () => {
   const testFile = tempy.file();
@@ -32,4 +34,21 @@ test("command is running in the same cwd", async () => {
   await waitForFile(testFile);
 
   expect(readFile(testFile)).toBe(process.cwd());
+});
+
+test("command is pushing ${cwd}/node_module/.bin to PATH", async () => {
+  const testFile = tempy.file();
+
+  newsh.command(`node ${writePATHFuncPath}`, {
+    env: {
+      __PATH__: testFile
+    }
+  });
+
+  await waitForFile(testFile);
+
+  const content = readFile(testFile);
+  const firstPATHChunk = content.slice(0, content.indexOf(":"));
+
+  expect(firstPATHChunk).toMatch(`node_modules${path.sep}.bin`);
 });

--- a/__tests__/utils/writePATH.js
+++ b/__tests__/utils/writePATH.js
@@ -1,0 +1,4 @@
+const fs = require("fs");
+const path = process.env.__PATH__;
+
+fs.writeFileSync(path, process.env.PATH);

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "type": "git",
     "url": "https://github.com/ranyitz/newsh"
   },
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "author": {
     "name": "Ran Yitzhaki",
     "email": "ranyitz@gmail.com",

--- a/src/command.ts
+++ b/src/command.ts
@@ -75,6 +75,12 @@ export default function command(
   const options = normalize(initialOptions);
   const isWindows = /^win/.test(process.platform);
 
+  const nodeModulesBin = path.join(options.cwd, "node_modules", ".bin");
+
+  if (fs.existsSync(nodeModulesBin)) {
+    options.env.PATH = `${nodeModulesBin}:${options.env.PATH}`;
+  }
+
   if (!isWindows) {
     commandUnix(script, options);
   } else {

--- a/src/command.ts
+++ b/src/command.ts
@@ -78,7 +78,11 @@ export default function command(
   const nodeModulesBin = path.join(options.cwd, "node_modules", ".bin");
 
   if (fs.existsSync(nodeModulesBin)) {
-    options.env.PATH = `${nodeModulesBin}:${options.env.PATH}`;
+    if (isWindows) {
+      options.env.Path = `${nodeModulesBin}:${options.env.Path}`;
+    } else {
+      options.env.PATH = `${nodeModulesBin}:${options.env.PATH}`;
+    }
   }
 
   if (!isWindows) {


### PR DESCRIPTION
This PR adds `${cwd}/node_modules/.bin` directory to `PATH`.

It means that the user can calls it's `bin` files from this directory, just like in `npm` scripts.

for example:

```sh
newsh jest --split
```

```sh
newsh "tsc --watch"
```
will now work. (if the project has them installed...)