### PR TITLE
add support for conEmu & --cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The main problem with this approach is that the developer is now required to und
 
 - 🌏 Cross-platform
 - 🗃 Opens the new shell in current working directory
-- 🎛 Supports splitting (`iterm2`/`tmux`)
+- 🎛 Supports splitting (`iterm2`/`tmux`/`ConEmu`/`Cmder`)
 - 📄 Runs js files with node
 - 🌴 Pass environment parameters to the new shell instance
 
@@ -98,6 +98,14 @@ Alias for `--split-vertically`
 
 Choose a specific terminal app to use (e.g. `iTerm.app`)
 
+### --cd
+
+Open the new shell in the specified directory
+
+```sh
+newsh pwd --cd "~"
+```
+
 ### --file
 
 Executes a file in a new shell
@@ -161,4 +169,4 @@ If you find a bug or want this project to provide better support for a certain t
 ## Future
 
 - Controll the focus of the terminal window
-- Better `split` integration with other terminals (`hyper`, `conEmu` and more)
+- Better `split` integration with other terminals

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -2,6 +2,7 @@ import tempy from "tempy";
 import runNewsh, { waitForFile, readFile } from "./utils/runNewsh";
 
 const writeFileFuncPath = require.resolve("./utils/writeFile");
+const writeCwdFuncPath = require.resolve("./utils/writeCwd.js");
 
 describe("cli", () => {
   test("command", async () => {
@@ -68,5 +69,23 @@ describe("cli", () => {
 
     await waitForFile(testFile, child);
     expect(readFile(testFile)).toBe(testData);
+  });
+
+  test("cd", async () => {
+    const testFile = tempy.file();
+    const testDirectory = tempy.directory();
+
+    const child = await runNewsh(
+      [`--cd=${testDirectory}`, `node ${writeCwdFuncPath}`],
+      {
+        env: {
+          __PATH__: testFile
+        }
+      }
+    );
+
+    await waitForFile(testFile, child);
+
+    expect(readFile(testFile)).toBe(testDirectory);
   });
 });

--- a/scripts/windows.bat
+++ b/scripts/windows.bat
@@ -1,0 +1,4 @@
+@echo off
+start /D %CD% cmd.exe @cmd /k %FILE_PATH%  
+pause
+exit

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ const args = arg(
     "--split-horizontally": Boolean,
     "--split-vertically": Boolean,
     "--terminalApp": String,
+    "--cd": String,
 
     // Aliases
     "-v": "--version",
@@ -50,6 +51,7 @@ const help = chalk`
     {bold $} {cyan newsh} --file path/to/script
     {bold $} {cyan newsh} --split "npx jest --watch"
     {bold $} {cyan newsh} --split-horizontally "npx tsc --watch"
+    {bold $} {cyan newsh} --cd ~
     {bold $} {cyan newsh} --help
     {bold $} {cyan newsh} --version
   
@@ -61,6 +63,7 @@ const help = chalk`
     --split-horizontally    Split the screen horizontally instead of opening a new one (iTerm2 & tmux only)
     --split                 Alias for --split-vertically
     --terminalApp           Choose a specific terminal app to use (e.g. iTerm.app)
+    --cd                    Open the new shell in the specified directory
 `;
 
 if (args["--help"]) {
@@ -89,6 +92,7 @@ const splitDirection = args["--split-vertically"]
 const initialOptions: InitialOptions = {
   env: {},
   cwd: undefined,
+  cd: args["--cd"],
   split: !!splitDirection,
   splitDirection,
   terminalApp: args["--terminalApp"]

--- a/src/command.ts
+++ b/src/command.ts
@@ -9,7 +9,7 @@ function commandWindows(script: string, options: Options): void {
   const launchFilePath = path.join(tempy.directory(), "launchTerminal.bat");
 
   const environmentParams = [];
-  const { env, cd } = options;
+  const { env } = options;
 
   if (env) {
     for (const paramKey in env) {
@@ -20,7 +20,7 @@ function commandWindows(script: string, options: Options): void {
   const batFile = `
 @echo off
 ${environmentParams.join("\n")}
-start /D ${cd} cmd.exe @cmd /k ${script}
+cmd.exe @cmd /k ${script}
 pause
 exit`;
 

--- a/src/launchTerminal.ts
+++ b/src/launchTerminal.ts
@@ -1,4 +1,12 @@
-import { linux, mac, windows, iterm, tmux, Launcher } from "./launchers";
+import {
+  linux,
+  mac,
+  windows,
+  iterm,
+  tmux,
+  Launcher,
+  conEmu
+} from "./launchers";
 import { Options } from "./normalize";
 import { ErrorMessage } from "./utils";
 
@@ -11,7 +19,7 @@ function chooseLauncher(options: Options): Launcher {
   const isIterm = ["iTerm", "iTerm.app", "iTerm2", "iTerm2.app"].includes(
     terminalApp!
   );
-
+  const isConEmu = !!process.env.ConEmuBuild;
   const isTmux = !!process.env.TMUX_PANE;
 
   if (split) {
@@ -22,6 +30,10 @@ function chooseLauncher(options: Options): Launcher {
     if (isIterm) {
       return iterm;
     }
+  }
+
+  if (isConEmu) {
+    return conEmu;
   }
 
   if (isMac) {

--- a/src/launchers.ts
+++ b/src/launchers.ts
@@ -1,14 +1,23 @@
 import execa from "execa";
 import path from "path";
 import { Options } from "./normalize";
+import { exec } from "child_process";
 
 export type Launcher = (execFilePath: string, options: Options) => void;
 
-export const windows: Launcher = execFilePath => {
-  execa.sync("cmd.exe", ["/C", execFilePath], {
-    detached: true,
-    stdio: "ignore"
-  });
+export const windows: Launcher = (execFilePath, options) => {
+  execa.sync(
+    "cmd.exe",
+    ["/C", path.join(__dirname, "../scripts/windows.bat")],
+    {
+      detached: true,
+      stdio: "ignore",
+      env: {
+        FILE_PATH: execFilePath,
+        CD: options.cd
+      }
+    }
+  );
 };
 
 export const linux: Launcher = (execFilePath, options) => {
@@ -57,5 +66,23 @@ export const tmux: Launcher = (execFilePath, options) => {
     } else {
       mac(execFilePath, options);
     }
+  }
+};
+
+export const conEmu: Launcher = (execFilePath, options) => {
+  let splitSuffix = "";
+
+  if (options.split) {
+    const conEmuSplitDirection =
+      options.splitDirection === "vertically" ? "H" : "V";
+    splitSuffix = `:s${conEmuSplitDirection}`;
+  }
+
+  try {
+    exec(
+      `cmd.exe -new_console${splitSuffix}:d:"${options.cd}" /k ${execFilePath}`
+    );
+  } catch (error) {
+    windows(execFilePath, options);
   }
 };

--- a/src/launchers.ts
+++ b/src/launchers.ts
@@ -80,7 +80,7 @@ export const conEmu: Launcher = (execFilePath, options) => {
 
   try {
     exec(
-      `cmd.exe -new_console${splitSuffix}:d:"${options.cd}" /k ${execFilePath}`
+      `cmd.exe -new_console${splitSuffix}:b:d:"${options.cd}" /k ${execFilePath}`
     );
   } catch (error) {
     windows(execFilePath, options);


### PR DESCRIPTION
This PR adds 3 things:

1. `ConEmu` & `Cmder` terminals splits support.

2. `--cd` option added as a CLI argument.

3. Refactor the way `windows` launcher works.