### PR TITLE
Add a file config + allow to specificy a terminalApp setup for linux

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ const help = chalk`
     --split-horizontally    Split the screen horizontally instead of opening a new one (iTerm2 & tmux only)
     --split                 Alias for --split-vertically
     --terminalApp           Choose a specific terminal app to use (e.g. iTerm.app)
-    --terminalAppSetup      The arguments to pass a file to execute, use {{file}} for file argument
+    --terminalAppSetup      The arguments to pass a file to execute, use \{\{file\}\} for file argument
     --cd                    Open the new shell in the specified directory
 `;
 
@@ -98,15 +98,16 @@ try {
   optionsFromFile = JSON.parse(fs.readFileSync("./.newsh.json").toString());
 } catch (e) {}
 
-const initialOptions: InitialOptions = Object.assign(optionsFromFile, {
+const initialOptions: InitialOptions = {
   env: {},
   cwd: undefined,
-  cd: args["--cd"],
-  split: !!splitDirection,
-  splitDirection,
-  terminalApp: args["--terminalApp"],
-  terminalAppSetup: args["--terminalAppSetup"]
-});
+  cd: args["--cd"] || optionsFromFile.cd,
+  split: !!(splitDirection || optionsFromFile.splitDirection),
+  splitDirection: splitDirection || optionsFromFile.splitDirection,
+  terminalApp: args["--terminalApp"] || optionsFromFile.terminalApp,
+  terminalAppSetup:
+    args["--terminalAppSetup"] || optionsFromFile.terminalAppSetup
+};
 
 scripts?.forEach(script => command(script, initialOptions));
 files?.forEach(filePath => launchFileInNewTerminal(filePath, initialOptions));

--- a/src/launchers/linux.ts
+++ b/src/launchers/linux.ts
@@ -2,8 +2,17 @@ import execa from "execa";
 import { Launcher } from "./";
 
 export const linux: Launcher = (execFilePath, options) => {
+  let argArray = ["-e", "{{file}}"];
+  if (options.terminalAppSetup !== undefined) {
+    argArray = options.terminalAppSetup.split(" ");
+  }
+  for (let i = 0; i < argArray.length; i++) {
+    if (argArray[i] === "{{file}}") {
+      argArray[i] = `sh ${execFilePath}`;
+    }
+  }
   try {
-    execa.sync(options.terminalApp!, ["-e", `sh ${execFilePath}`], {
+    execa.sync(options.terminalApp!, argArray, {
       detached: true
     });
   } catch (error) {

--- a/src/launchers/mac.ts
+++ b/src/launchers/mac.ts
@@ -11,6 +11,10 @@ export const mac: Launcher = (execFilePath, options) => {
 
   const isTmux = !!process.env.TMUX_PANE;
 
+  if (options.terminalAppSetup !== undefined) {
+    console.error(`terminalAppSetup not supported on mac yet`);
+  }
+
   try {
     if (isTmux && split) {
       return tmux(execFilePath, options);

--- a/src/launchers/windows.ts
+++ b/src/launchers/windows.ts
@@ -18,16 +18,30 @@ const startWindows: Launcher = (execFilePath, options) => {
   );
 };
 
-export const windows: Launcher = (execFilePath, options) => {
-  const isConEmu = !!process.env.ConEmuBuild;
+const tryConEmu: Launcher = (execFilePath, options) => {
+  try {
+    return conEmu(execFilePath, options);
+  } catch (error) {
+    return startWindows(execFilePath, options);
+  }
+};
 
-  if (isConEmu) {
-    try {
-      return conEmu(execFilePath, options);
-    } catch (error) {
+export const windows: Launcher = (execFilePath, options) => {
+  if (options.terminalAppSetup !== undefined) {
+    console.error(`terminalAppSetup not supported on windows yet`);
+  }
+  if (options.terminalApp !== undefined) {
+    if (options.terminalApp.toLowerCase() === "cmd") {
       return startWindows(execFilePath, options);
+    } else if (options.terminalApp.toLowerCase() === "conemu") {
+      return tryConEmu(execFilePath, options);
+    } else {
+      console.error(`terminalApp "${options.terminalApp}" not supported`);
     }
   }
-
-  startWindows(execFilePath, options);
+  const isConEmu = !!process.env.ConEmuBuild;
+  if (isConEmu) {
+    return tryConEmu(execFilePath, options);
+  }
+  return startWindows(execFilePath, options);
 };

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -8,6 +8,7 @@ export type Options = {
   split: boolean;
   splitDirection: "vertically" | "horizontally";
   terminalApp: string | undefined;
+  terminalAppSetup?: string | undefined;
 };
 
 const defaultOptions: Options = {


### PR DESCRIPTION
we can now have a `.newsh` file that configure the options
This is very useful as each user might have different preferences

This PR also add terminalAppSetup with is a string of argument to support terminal that do not use the usual `-e <file>` setup on linux

user can now specific a string like `newsh --terminalAppSetup="-e {{file}}"` to achieve the same